### PR TITLE
Add undo and redo support!

### DIFF
--- a/blocks/block.js
+++ b/blocks/block.js
@@ -309,9 +309,7 @@ class Block extends Component {
           ...script.position
         }
       } else {
-        target = {
-          indices: this.getIndices()
-        }
+        target = { indices: this.getIndices() }
       }
     }
     return this.blocks.dragBlocks({

--- a/blocks/block.js
+++ b/blocks/block.js
@@ -126,6 +126,10 @@ class Block extends Component {
     return params
   }
 
+  getParamComponent (paramID) {
+    return this._params[paramID]
+  }
+
   getParamID (component) {
     for (const [paramID, input] of Object.entries(this._params)) {
       if (input === component) {
@@ -323,13 +327,13 @@ class Block extends Component {
         }
       }
     }
-    // script.setPosition(workspaceX + x - left, workspaceY + y - top)
     return this.blocks.dragBlocks({
       target,
-      dx: initMouseX - script.position.x,
-      dy: initMouseY - script.position.y,
-      type: this.blockData.blockType,
-      onReady: script.resize()
+      initMouseX,
+      initMouseY,
+      scriptX: workspaceX + x - left,
+      scriptY: workspaceY + y - top,
+      type: this.blockData.blockType
     })
   }
 

--- a/blocks/block.js
+++ b/blocks/block.js
@@ -1,6 +1,6 @@
 import { Elem } from '../utils/elem.js'
 
-import { Component, TextComponent } from './component.js'
+import { Component, TextComponent, getIndicesOf } from './component.js'
 import { BlockType, ArgumentType, NullCategory } from './constants.js'
 import { Input, StringInput, NumberInput, AngleInput, BooleanInput } from './input.js'
 import { Stack, Script } from './scripts.js'
@@ -287,10 +287,6 @@ class Block extends Component {
     this.trigger('reposition', this.measurements)
   }
 
-  getIndices () {
-    return Block.getIndices(this)
-  }
-
   _onDrag (initMouseX, initMouseY) {
     const workspace = this.getWorkspace()
     const { x, y } = this.getWorkspaceOffset()
@@ -309,7 +305,7 @@ class Block extends Component {
           ...script.position
         }
       } else {
-        target = { indices: this.getIndices() }
+        target = { indices: getIndicesOf(this) }
       }
     }
     return this.blocks.dragBlocks({
@@ -370,23 +366,6 @@ class Block extends Component {
       opcode: this.blockOpcode,
       params
     }
-  }
-
-  static getIndices (component) {
-    const indices = []
-    while (component.parent) {
-      if (component.parent instanceof Block) {
-        indices.unshift(component.parent.getParamID(component))
-      } else if (!(component.parent instanceof Input)) {
-        indices.unshift(component.parent.components.indexOf(component))
-      }
-      component = component.parent
-    }
-    if (component.workspace) {
-      indices.unshift(component.workspace.scripts.indexOf(component))
-      indices.unshift(component.workspace)
-    }
-    return indices
   }
 }
 

--- a/blocks/block.js
+++ b/blocks/block.js
@@ -288,21 +288,7 @@ class Block extends Component {
   }
 
   getIndices () {
-    const indices = []
-    let component = this
-    while (component.parent) {
-      if (component.parent instanceof Block) {
-        indices.unshift(component.parent.getParamID(component))
-      } else if (!(component.parent instanceof Input)) {
-        indices.unshift(component.parent.components.indexOf(component))
-      }
-      component = component.parent
-    }
-    if (component.workspace) {
-      indices.unshift(component.workspace.scripts.indexOf(component))
-      indices.unshift(component.workspace)
-    }
-    return indices
+    return Block.getIndices(this)
   }
 
   _onDrag (initMouseX, initMouseY) {
@@ -316,10 +302,11 @@ class Block extends Component {
     } else {
       if (this.parent instanceof Script && this.parent.components[0] === this) {
         // Dragging the entire script, effectively
+        const script = this.parent
         target = {
-          workspace: this.parent,
-          index: this.parent.components.indexOf(this),
-          ...this.parent.position
+          workspace,
+          index: workspace.scripts.indexOf(script),
+          ...script.position
         }
       } else {
         target = {
@@ -385,6 +372,23 @@ class Block extends Component {
       opcode: this.blockOpcode,
       params
     }
+  }
+
+  static getIndices (component) {
+    const indices = []
+    while (component.parent) {
+      if (component.parent instanceof Block) {
+        indices.unshift(component.parent.getParamID(component))
+      } else if (!(component.parent instanceof Input)) {
+        indices.unshift(component.parent.components.indexOf(component))
+      }
+      component = component.parent
+    }
+    if (component.workspace) {
+      indices.unshift(component.workspace.scripts.indexOf(component))
+      indices.unshift(component.workspace)
+    }
+    return indices
   }
 }
 

--- a/blocks/block.js
+++ b/blocks/block.js
@@ -1,9 +1,26 @@
 import { Elem } from '../utils/elem.js'
 
-import { Component, TextComponent, getIndicesOf } from './component.js'
+import { Component, TextComponent } from './component.js'
 import { BlockType, ArgumentType, NullCategory } from './constants.js'
 import { Input, StringInput, NumberInput, AngleInput, BooleanInput } from './input.js'
 import { Stack, Script } from './scripts.js'
+
+function getIndicesOf (component) {
+  const indices = []
+  while (component.parent) {
+    if (component.parent instanceof Block) {
+      indices.unshift(component.parent.getParamID(component))
+    } else if (!(component.parent instanceof Input)) {
+      indices.unshift(component.parent.components.indexOf(component))
+    }
+    component = component.parent
+  }
+  if (component.workspace) {
+    indices.unshift(component.workspace.scripts.indexOf(component))
+    indices.unshift(component.workspace)
+  }
+  return indices
+}
 
 class Block extends Component {
   constructor (blocks, initBlock, initParams = {}) {
@@ -414,4 +431,4 @@ Block.renderOptions = {
 
 Block.maxSnapDistance = 30
 
-export { Block }
+export { Block, getIndicesOf }

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -167,7 +167,7 @@ class Blocks extends Newsletter {
     }
     this._dragging++
     // If the first block is a reporter, then only pull out one block.
-    const script = this.grabTarget(target, type === BlockType.COMMAND ? Infinity : 1)
+    const script = this._grabTarget(target, type === BlockType.COMMAND ? Infinity : 1)
     script.setPosition(scriptX, scriptY)
     this._dragSvg.appendChild(script.elem)
     const dx = initMouseX - scriptX
@@ -381,7 +381,7 @@ class Blocks extends Newsletter {
           // TODO: This should just send it back to its original position.
           undoEntry.b = script.toJSON().blocks
         }
-        const extraSteps = this.shoveTarget(undoEntry.b, script)
+        const extraSteps = this._shoveTarget(undoEntry.b, script)
         this.addUndoEntry(extraSteps ? [...extraSteps, undoEntry] : undoEntry)
       }
     }
@@ -394,7 +394,7 @@ class Blocks extends Newsletter {
    *   taking from within a stack - required)
    * @returns {Script}
    */
-  grabTarget (data, blockCount = 0) {
+  _grabTarget (data, blockCount = 0) {
     if (Array.isArray(data)) {
       // Is an array of block JSONs (implying it is a concept to be realized)
       const script = this.scriptFromJSON({ x: 0, y: 0, blocks: data })
@@ -476,9 +476,9 @@ class Blocks extends Newsletter {
   }
 
   /**
-   * Intended to be the reverse of whatever is done in `grabTarget`
+   * Intended to be the reverse of whatever is done in `_grabTarget`
    */
-  shoveTarget (data, script) {
+  _shoveTarget (data, script) {
     if (Array.isArray(data)) {
       script.destroy()
     } else if (data.indices) {
@@ -577,7 +577,7 @@ class Blocks extends Newsletter {
     const b = flip ? entry.a : entry.b
     switch (entry.type) {
       case 'transfer': {
-        this.shoveTarget(b, this.grabTarget(a, entry.blocks))
+        this._shoveTarget(b, this._grabTarget(a, entry.blocks))
         break
       }
       default:

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -7,7 +7,7 @@ import { PaletteWorkspace, paletteRenderOptions } from './palette.js'
 import { BlockType, ArgumentType } from './constants.js'
 import { Stack, Script } from './scripts.js'
 import { Block } from './block.js'
-import { Space } from './component.js'
+import { Space, getIndicesOf } from './component.js'
 import { Input } from './input.js'
 
 class Blocks extends Newsletter {
@@ -510,7 +510,7 @@ class Blocks extends Newsletter {
           undoEntry = {
             type: 'transfer',
             a: {
-              indices: oldValue.getIndices()
+              indices: getIndicesOf(oldValue)
             },
             b: {
               workspace,

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -6,8 +6,8 @@ import { Workspace, ScriptsWorkspace } from './workspace.js'
 import { PaletteWorkspace, paletteRenderOptions } from './palette.js'
 import { BlockType, ArgumentType } from './constants.js'
 import { Stack, Script } from './scripts.js'
-import { Block } from './block.js'
-import { Space, getIndicesOf } from './component.js'
+import { Block, getIndicesOf } from './block.js'
+import { Space } from './component.js'
 import { Input } from './input.js'
 
 function getComponentFromIndices (indicesArray) {

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -28,7 +28,11 @@ function getComponentFromIndices (indicesArray) {
       component = component.getParamComponent(index)
     }
   }
-  return { parent, component }
+  return {
+    parent,
+    component,
+    index: indices[indices.length - 1]
+  }
 }
 
 class Blocks extends Newsletter {
@@ -424,7 +428,7 @@ class Blocks extends Newsletter {
     } else if (data.indices) {
       // Probably means the block was dragged out from a script such that the
       // old script still remains.
-      const { component } = getComponentFromIndices(data.indices)
+      const { component, index } = getComponentFromIndices(data.indices)
       const script = this.createScript()
       if (component instanceof Input) {
         const block = component.getValue()
@@ -445,7 +449,7 @@ class Blocks extends Newsletter {
         // Subtraction because this is actually the inverse of the normal operation
         // which is done in the shove step.
         parent.setPosition(x - dx, y - dy)
-        let index = indices[indices.length - 1]
+        let i = 0
         if (data.branchAround) {
           const branch = component.getParamComponent(data.branchAround)
           // Move branch contents outside right above the branch
@@ -453,8 +457,8 @@ class Blocks extends Newsletter {
           while (branch.components[0]) {
             const component = branch.components[0]
             branch.remove(component)
-            parent.add(component, index)
-            index++
+            parent.add(component, index + i)
+            i++
           }
           branch.resize()
         }
@@ -463,7 +467,7 @@ class Blocks extends Newsletter {
         // Takes all the blocks after that point or only the given number
         // of blocks (`blockCount`).
         while (blocks < blockCount) {
-          const component = parent.components[index]
+          const component = parent.components[index + i]
           if (!component) break
           parent.remove(component)
           script.add(component)
@@ -489,7 +493,7 @@ class Blocks extends Newsletter {
     if (Array.isArray(data)) {
       script.destroy()
     } else if (data.indices) {
-      const { parent, component } = getComponentFromIndices(data.indices)
+      const { parent, component, index} = getComponentFromIndices(data.indices)
       if (component instanceof Input) {
         let undoEntry
         const oldValue = component.getValue()
@@ -528,22 +532,22 @@ class Blocks extends Newsletter {
         const { x, y } = parent.position
         parent.setPosition(x + dx, y + dy)
         const firstBlock = script.components[0]
-        let index = indices[indices.length - 1]
         // Inserts all of the blocks in the carrier script into the target
         // stack
+        let i = 0
         while (script.components.length) {
           const block = script.components[0]
           script.remove(block)
-          parent.add(block, index)
-          index++
+          parent.add(block, index + i)
+          i++
         }
         const prom = Promise.resolve().then(() => parent.resize())
         if (data.branchAround) {
           const branch = firstBlock.getParamComponent(data.branchAround)
           // Insert all the blocks after the insert point that were already in the
           // target stack in the branch block
-          while (parent.components[index]) {
-            branch.add(parent.components[index])
+          while (parent.components[index + i]) {
+            branch.add(parent.components[index + i])
           }
           // Ensure that the parent's other children are measured first
           prom.then(() => branch.resize())

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -503,7 +503,6 @@ class Blocks extends Newsletter {
         let undoEntry
         const oldValue = component.getValue()
         if (oldValue instanceof Block) {
-          // TODO: another undo entry for popping out a block??
           // NOTE: Scratch puts it on the right of the script, vertically
           // in the middle. (That is not done here)
           const offset = Input.renderOptions.popOutOffset

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -426,12 +426,22 @@ class Blocks extends Newsletter {
         // it and its younger siblings will be deported. Not all though if this
         // is a reverse of block stack insertion.
         const parent = component.parent
-        const {dx = 0, dy = 0} = data
-        const {x, y} = component.parent.position
+        const { dx = 0, dy = 0 } = data
+        const { x, y } = parent.position
         // Subtraction because this is actually the inverse of the normal operation
         // which is done in the shove step.
-        component.parent.setPosition(x - dx, y - dy)
-        const index = indices[indices.length - 1]
+        parent.setPosition(x - dx, y - dy)
+        let index = indices[indices.length - 1]
+        if (data.branchAround) {
+          const branch = component.getParamComponent(data.branchAround)
+          while (branch.components[0]) {
+            const component = branch.components[0]
+            branch.remove(component)
+            parent.add(component, index)
+            index++
+          }
+          branch.resize()
+        }
         let blocks = 0
         while (blocks < blockCount) {
           const component = parent.components[index]
@@ -505,15 +515,23 @@ class Blocks extends Newsletter {
         }
       } else {
         // Shift target script
-        const {dx = 0, dy = 0} = data
-        const {x, y} = parent.position
+        const { dx = 0, dy = 0 } = data
+        const { x, y } = parent.position
         parent.setPosition(x + dx, y + dy)
+        const firstBlock = script.components[0]
         let index = indices[indices.length - 1]
         while (script.components.length) {
           const block = script.components[0]
           script.remove(block)
           parent.add(block, index)
           index++
+        }
+        if (data.branchAround) {
+          const branch = firstBlock.getParamComponent(data.branchAround)
+          while (parent.components[index]) {
+            branch.add(parent.components[index])
+          }
+          branch.resize()
         }
         parent.resize()
       }

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -528,7 +528,7 @@ class Blocks extends Newsletter {
         if (script.components.length) {
           script.destroy()
         }
-        return [undoEntry]
+        return undoEntry && [undoEntry]
       } else {
         // Shift target script
         const { dx = 0, dy = 0 } = data

--- a/blocks/component.js
+++ b/blocks/component.js
@@ -237,21 +237,4 @@ class Space extends Component {
   }
 }
 
-static getIndicesOf (component) {
-  const indices = []
-  while (component.parent) {
-    if (component.parent instanceof Block) {
-      indices.unshift(component.parent.getParamID(component))
-    } else if (!(component.parent instanceof Input)) {
-      indices.unshift(component.parent.components.indexOf(component))
-    }
-    component = component.parent
-  }
-  if (component.workspace) {
-    indices.unshift(component.workspace.scripts.indexOf(component))
-    indices.unshift(component.workspace)
-  }
-  return indices
-}
-
-export { TextComponent, Component, Space, getIndicesOf }
+export { TextComponent, Component, Space }

--- a/blocks/component.js
+++ b/blocks/component.js
@@ -237,4 +237,21 @@ class Space extends Component {
   }
 }
 
-export { TextComponent, Component, Space }
+static getIndicesOf (component) {
+  const indices = []
+  while (component.parent) {
+    if (component.parent instanceof Block) {
+      indices.unshift(component.parent.getParamID(component))
+    } else if (!(component.parent instanceof Input)) {
+      indices.unshift(component.parent.components.indexOf(component))
+    }
+    component = component.parent
+  }
+  if (component.workspace) {
+    indices.unshift(component.workspace.scripts.indexOf(component))
+    indices.unshift(component.workspace)
+  }
+  return indices
+}
+
+export { TextComponent, Component, Space, getIndicesOf }

--- a/blocks/component.js
+++ b/blocks/component.js
@@ -64,6 +64,16 @@ class GenericComponent extends Newsletter {
     }
     return parent.workspace
   }
+
+  destroy () {
+    if (this.parent) {
+      throw new Error('Component cannot be destroyed in plain sight.')
+    }
+    this.elem = null
+    this.destroy = () => {
+      console.warn('I am being destroyed TWICE!')
+    }
+  }
 }
 
 class TextComponent extends GenericComponent {
@@ -106,13 +116,6 @@ class TextComponent extends GenericComponent {
         resolve(this.measurements)
       })
     })
-  }
-
-  destroy () {
-    if (this.parent) {
-      throw new Error('Component cannot be destroyed in plain sight.')
-    }
-    this.elem = null
   }
 }
 
@@ -198,15 +201,12 @@ class Component extends GenericComponent {
    * This is not suicide; this is the obliteration of the SELF.
    */
   destroy () {
-    if (this.parent) {
-      throw new Error('Component cannot be destroyed in plain sight.')
-    }
     while (this.components[0]) {
       const component = this.components[0]
       this.remove(component)
       component.destroy()
     }
-    this.elem = null
+    super.destroy()
   }
 }
 

--- a/blocks/component.js
+++ b/blocks/component.js
@@ -180,11 +180,9 @@ class Component extends GenericComponent {
       // Abort an ongoing resizing attempt.
       this._resizing()
     }
+    // Allow later resize calls to abort earlier ones in progress.
     let aborted = false
-    const abort = new Promise(resolve => {
-      // Allow later resize calls to abort earlier ones in progress.
-      this._resizing = resolve
-    }).then(() => (aborted = true))
+    this._resizing = () => (aborted = true)
     await Promise.all(this.components.map(component => {
       if (!component.measurements || force) {
         return component.resize(force, false)

--- a/blocks/palette.js
+++ b/blocks/palette.js
@@ -220,7 +220,7 @@ class PaletteWorkspace extends ScriptsWorkspace {
     this.trigger('scroll-bounds', this._scrollBounds)
   }
 
-  acceptDrop (script, x, y) {
+  dropBlocks ({ script }) {
     return script.toJSON().blocks
   }
 

--- a/blocks/palette.js
+++ b/blocks/palette.js
@@ -221,7 +221,7 @@ class PaletteWorkspace extends ScriptsWorkspace {
   }
 
   acceptDrop (script, x, y) {
-    script.destroy()
+    return script.toJSON().blocks
   }
 
   getStackBlockConnections () {

--- a/blocks/playground.html
+++ b/blocks/playground.html
@@ -150,7 +150,8 @@
       <button id="toggle-dir">Toggle dir</button><br>
       <button id="toggle-fat">Toggle fatness</button><br>
       <button id="sprinkles">Sprinkles!</button><br>
-      <button id="spaghetti">Spaghetti!</button>
+      <button id="spaghetti">Spaghetti!</button><br>
+      <button id="undo" disabled>Undo</button><button id="redo" disabled>Redo</button>
     </div>
     <div class="palette-wrapper">
       <div id="categories"></div>
@@ -545,6 +546,19 @@ document.getElementById('toggle-fat').addEventListener('click', e => {
     }
   }
   blocks.resizeAll()
+})
+
+const undoBtn = document.getElementById('undo')
+const redoBtn = document.getElementById('redo')
+undoBtn.addEventListener('click', e => {
+  blocks.undo()
+})
+redoBtn.addEventListener('click', e => {
+  blocks.redo()
+})
+blocks.on('undo-redo-available', (undo, redo) => {
+  undoBtn.disabled = !undo
+  redoBtn.disabled = !redo
 })
 
 // Based on scratch-blocks:

--- a/blocks/scripts.js
+++ b/blocks/scripts.js
@@ -95,6 +95,7 @@ class Script extends Stack {
     super.remove(component)
     if (!this.components.length) {
       this.removeFromWorkspace()
+      this.destroy()
     }
   }
 

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -118,7 +118,6 @@ class Workspace extends Newsletter {
       if (snapTo instanceof Input) {
         return { indices: Block.getIndices(snapTo) }
       } else if (snapTo.insertBefore) {
-        const index = snapTo.in.components.indexOf(snapTo.insertBefore)
         if (wrappingC) {
           const firstBranch = script.components[0].components
             .find(component => component instanceof Stack)
@@ -129,24 +128,6 @@ class Workspace extends Newsletter {
             // Referencing by param ID in case the language changes
             branchAround: script.components[0].getParamID(firstBranch)
           }
-          const blocksInserted = script.components.length
-          while (script.components.length) {
-            const component = script.components[script.components.length - 1]
-            script.remove(component)
-            snapTo.in.add(component, index)
-          }
-          while (snapTo.in.components[blocksInserted + index]) {
-            const component = snapTo.in.components[blocksInserted + index]
-            snapTo.in.remove(component)
-            firstLoop.add(component)
-          }
-          if (snapTo.beforeScript) {
-            snapTo.in.setPosition(
-              snapTo.in.position.x - firstLoop.position.x,
-              snapTo.in.position.y - firstLoop.position.y
-            )
-          }
-          return firstLoop.resize()
         } else {
           return {
             indices: snapTo.insertBefore.getIndices(),
@@ -154,10 +135,12 @@ class Workspace extends Newsletter {
           }
         }
       } else if (snapTo.after) {
-        return { indices: [
-          ...Block.getIndices(snapTo.in),
-          snapTo.in.components.length
-        ] }
+        return {
+          indices: [
+            ...Block.getIndices(snapTo.in),
+            snapTo.in.components.length
+          ]
+        }
       }
     } else {
       return {

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -100,20 +100,10 @@ class Workspace extends Newsletter {
     })
 
     blocks.onDrag(this.wrapper, this._onStartScroll.bind(this))
-    blocks.onDrop(this.wrapper, {
-      acceptDrop: this.acceptDrop.bind(this),
-      getStackBlockConnections: this.getStackBlockConnections.bind(this),
-      getReporterConnections: this.getReporterConnections.bind(this),
-      getRect: () => {
-        return this.rect
-      },
-      getTransform: () => {
-        return this.transform
-      }
-    })
+    blocks.onDrop(this.wrapper, this)
   }
 
-  acceptDrop (script, x, y, snapTo, wrappingC, undoEntry) {
+  dropBlocks ({ script, x, y, snapTo, wrappingC }) {
     if (snapTo) {
       if (snapTo instanceof Input) {
         return { indices: Block.getIndices(snapTo) }
@@ -360,11 +350,6 @@ class ScriptsWorkspace extends Workspace {
     this._horizScrollbar = new Scrollbar(this, true)
     this._vertScrollbar = new Scrollbar(this, false)
   }
-
-  // acceptDrop (...args) {
-  //   return super.acceptDrop(...args)
-  //     .then(() => this.updateScroll())
-  // }
 
   /**
    * Get the bounding box of all the scripts in the workspace to determine the

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -126,6 +126,7 @@ class Workspace extends Newsletter {
             indices: snapTo.insertBefore.getIndices(),
             dx: snapTo.beforeScript ? -firstBranch.position.x : 0,
             dy: snapTo.beforeScript ? -firstBranch.position.y : 0,
+            // Referencing by param ID in case the language changes
             branchAround: script.components[0].getParamID(firstBranch)
           }
           const blocksInserted = script.components.length

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -2,6 +2,7 @@ import { Elem } from '../utils/elem.js'
 import { pythagoreanCompare } from '../utils/math.js'
 import { Newsletter } from '../utils/newsletter.js'
 
+import { getIndicesOf } from './component.js'
 import { Input } from './input.js'
 import { Block } from './block.js'
 import { Stack } from './scripts.js'
@@ -106,13 +107,13 @@ class Workspace extends Newsletter {
   dropBlocks ({ script, x, y, snapTo, wrappingC }) {
     if (snapTo) {
       if (snapTo instanceof Input) {
-        return { indices: Block.getIndices(snapTo) }
+        return { indices: getIndicesOf(snapTo) }
       } else if (snapTo.insertBefore) {
         if (wrappingC) {
           const firstBranch = script.components[0].components
             .find(component => component instanceof Stack)
           return {
-            indices: snapTo.insertBefore.getIndices(),
+            indices: getIndicesOf(snapTo.insertBefore),
             dx: snapTo.beforeScript ? -firstBranch.position.x : 0,
             dy: snapTo.beforeScript ? -firstBranch.position.y : 0,
             // Referencing by param ID in case the language changes
@@ -120,14 +121,14 @@ class Workspace extends Newsletter {
           }
         } else {
           return {
-            indices: snapTo.insertBefore.getIndices(),
+            indices: getIndicesOf(snapTo.insertBefore),
             dy: snapTo.beforeScript ? -script.measurements.height : 0
           }
         }
       } else if (snapTo.after) {
         return {
           indices: [
-            ...Block.getIndices(snapTo.in),
+            ...getIndicesOf(snapTo.in),
             snapTo.in.components.length
           ]
         }

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -2,9 +2,8 @@ import { Elem } from '../utils/elem.js'
 import { pythagoreanCompare } from '../utils/math.js'
 import { Newsletter } from '../utils/newsletter.js'
 
-import { getIndicesOf } from './component.js'
 import { Input } from './input.js'
-import { Block } from './block.js'
+import { Block, getIndicesOf } from './block.js'
 import { Stack } from './scripts.js'
 import { Scrollbar } from './scrollbar.js'
 

--- a/blocks/workspace.js
+++ b/blocks/workspace.js
@@ -120,8 +120,14 @@ class Workspace extends Newsletter {
       } else if (snapTo.insertBefore) {
         const index = snapTo.in.components.indexOf(snapTo.insertBefore)
         if (wrappingC) {
-          const firstLoop = script.components[0].components
+          const firstBranch = script.components[0].components
             .find(component => component instanceof Stack)
+          return {
+            indices: snapTo.insertBefore.getIndices(),
+            dx: snapTo.beforeScript ? -firstBranch.position.x : 0,
+            dy: snapTo.beforeScript ? -firstBranch.position.y : 0,
+            branchAround: script.components[0].getParamID(firstBranch)
+          }
           const blocksInserted = script.components.length
           while (script.components.length) {
             const component = script.components[script.components.length - 1]


### PR DESCRIPTION
It is quite a sophisticated approach: block dragging is made reverseable by defining how to get all possible start and/or end states (eg being created/deleted or being inserted into a stack) into a stack of blocks, and how to get from those blocks back to one of those states (like atoms in a reaction breaking bonds before forming new ones)

This implementation is friendly to both block dragging and the undo/redo buttons. It is not a perfect implementation probably; I expect Mr. Sean of the Tomorrow to test this with the Mind of the Morning before merging. One issue that may arise is if the reverse process is not ideal, causing artefacts to appear if one repeatedly went undo and redo

I ask Mr. Sean on Github's Light Theme Interface to inspect the code for opportunities to merge the two steps earlier mentioned since I think they're a bit repetitive

This does not add support for undo/redoing input value changes

Blockly also makes all actions reverseable, and their way is undeniably the most intelligent

wucky